### PR TITLE
Create a `MSLServerTrustManager`

### DIFF
--- a/Sources/MSLNetworking/CharlesProxyEvaluator.swift
+++ b/Sources/MSLNetworking/CharlesProxyEvaluator.swift
@@ -48,18 +48,3 @@ internal class CharlesProxyEvaluator: ServerTrustEvaluating {
         }
     }
 }
-
-
-internal final class MSLServerTrustManager: ServerTrustManager {
-    
-    private let serverTrustEvaluating: ServerTrustEvaluating
-    
-    public init(charlesCertBundle: Bundle) {
-        self.serverTrustEvaluating = CharlesProxyEvaluator(certBundle: charlesCertBundle)
-        super.init(evaluators: [:])
-    }
-    
-    override public func serverTrustEvaluator(forHost host: String) throws -> ServerTrustEvaluating? {
-        return self.serverTrustEvaluating
-    }
-}

--- a/Sources/MSLNetworking/MSLNetworking.swift
+++ b/Sources/MSLNetworking/MSLNetworking.swift
@@ -3,13 +3,10 @@ import Foundation
 
 /// Foundational helpers for all Michigan Software Labs projects
 public struct MSLNetworking {
-    /// Generate a ServerTrustManager to be used with AlamoFire to allow for proxying requests
-    /// through Charles running on your development environment. Charles Proxy should only be used
-    /// in DEBUG mode.
-    ///
+    /// Builds a Server Trust Evaluator that trusts network requests intended to pass through Charles Proxy.
     /// - Parameter charlesCertBundle: The bundle containing the Charles Certificate
-    /// - Returns: A `ServerTrustManager` that allows for successful proxying with the provided certifcate
-    public static func generateServerTrustManager(charlesCertBundle: Bundle) -> ServerTrustManager {
-        return MSLServerTrustManager(charlesCertBundle: charlesCertBundle)
+    /// - Returns: A `ServerTrustEvaluating` that allows for successful proxying with the provided certifcate
+    public static func charlesProxyEvaluator(_ bundle: Bundle) -> ServerTrustEvaluating {
+        return CharlesProxyEvaluator(certBundle: bundle)
     }
 }

--- a/Sources/MSLNetworking/MSLServerTrustManager.swift
+++ b/Sources/MSLNetworking/MSLServerTrustManager.swift
@@ -1,0 +1,28 @@
+import Alamofire
+
+/// A Server Trust Manager with designed to uses the provided `evaluators` first, and then
+/// fall back to the `defaultEvaluator` in the case an evaluator was not provided for a specific host.
+public final class MSLServerTrustManager: ServerTrustManager {
+
+    public var defaultEvaluator: ServerTrustEvaluating?
+
+    public init(
+        allHostsMustBeEvaluated: Bool = true,
+        evaluators: [String: ServerTrustEvaluating],
+        defaultEvaluator: ServerTrustEvaluating? = nil
+    ) {
+        self.defaultEvaluator = defaultEvaluator
+
+        super.init(allHostsMustBeEvaluated: allHostsMustBeEvaluated, evaluators: evaluators)
+    }
+
+    override public func serverTrustEvaluator(forHost host: String) throws -> ServerTrustEvaluating? {
+        if let evaluator = self.evaluators[host] {
+            return evaluator
+        } else if let evaluator = self.defaultEvaluator {
+            return evaluator
+        } else {
+            return nil
+        }
+    }
+}

--- a/Sources/MSLNetworking/documentation/charles_proxy.md
+++ b/Sources/MSLNetworking/documentation/charles_proxy.md
@@ -47,7 +47,7 @@ public class ApiService {
     let session: Session
 
     public init(serverUrl: String) {
-        var serverTrustManager: ServerTrustManager?
+        var serverTrustManager = MSLServerTrustManager()
 
         #if DEBUG
             // We only want to use the Charles Proxy Evaluator when we are debugging
@@ -55,7 +55,7 @@ public class ApiService {
                 let url = Bundle.module.url(forResource: "SSLCertificates", withExtension: "bundle"),
                 let bundle = Bundle(url: url)
             {
-                serverTrustManager = MSLNetworking.generateServerTrustManager(charlesCertBundle: bundle)
+                serverTrustManager.defaultEvaluator = MSLNetworking.charlesProxyEvaluator(charlesCertBundle: bundle)
             }
         #endif
 


### PR DESCRIPTION
MSLServerTrustManager allows for a `defaultEvaluator` to be set which is useful if you want some network traffic to go through the Charles proxy Trust Evaluator and other traffic to have a pinned cert (for example).