### PR TITLE
View extension isHidden helper function

### DIFF
--- a/Sources/MSLSwiftUI/View+Hidden.swift
+++ b/Sources/MSLSwiftUI/View+Hidden.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+public extension View {
+
+    /// A View extension that allows the passing of a boolean to determine if a View is shown or not on screen.
+    /// - Parameter hidden: Determines if the View is displayed on the screen or not.
+    /// - Returns: The View with the hidden view modifier added or not.
+    @ViewBuilder
+    func isHidden(_ hidden: Bool) -> some View {
+        if hidden {
+            self.hidden()
+        } else {
+            self
+        }
+    }
+}


### PR DESCRIPTION
This is a helper function that extends View in SwiftUI.
It will allow you to pass in a boolean and conditionally hide the View.
Before you could only unconditionally hide a View with ```.hidden()```, but now you can pass in a boolean.